### PR TITLE
Fixed Input_Config.xml and Localisation.sql

### DIFF
--- a/Base/UI/Text/Input_Config.xml
+++ b/Base/UI/Text/Input_Config.xml
@@ -52,6 +52,6 @@
 		<Row ActionId="ToggleEra" Index="0" GestureType="KBMouse" GestureData="NONE"/>
 		<Row ActionId="ToggleObs" Index="0" GestureType="KBMouse" GestureData="NONE"/>
 		<Row ActionId="ToggleDiplomaticFavor" Index="0" GestureType="KBMouse" GestureData="NONE"/>
-		<Row ActionId="Toggle5movement" Index="0" GestureType="KBMouse" GestureData="NONE"/>
+		<Row ActionId="Toggle5Movement" Index="0" GestureType="KBMouse" GestureData="NONE"/>
 	</InputActionDefaultGestures>
 </GameInfo>

--- a/Base/UI/Text/Localisation.sql
+++ b/Base/UI/Text/Localisation.sql
@@ -117,7 +117,7 @@ VALUES
 		("LOC_DESTROY_CITY_DISTRICTS_LABEL",		"zh_Hans_CN",	"地区："),
 		("LOC_RAZE_CITY_EXPLANATION",				"zh_Hans_CN",	"摧毁所选城市"),
 		("LOC_KEEP_CITY_EXPLANATION",				"zh_Hans_CN",	"暂时将这座城市留在你的帝国。"),
-		("LOC_DESTROY_CITY_LIBERATE_EXPLANATION",	"zh_Hans_CN",	"解放一个城市将把它归还给他们之前的一个所有者,	可能会把这个文明带回游戏中。");
+		("LOC_DESTROY_CITY_LIBERATE_EXPLANATION",	"zh_Hans_CN",	"解放一个城市将把它归还给他们之前的一个所有者,	可能会把这个文明带回游戏中。"),
 -- Japanese ------------------------------------------------------------------------------------------------------------
 		("LOC_CHEAT_MENU_ABOUT",  					"ja_JP",		"Cheat Panel By [Sparrow]"),
 		("LOC_CHEAT_EXPAND_MAX",  					"ja_JP",		"Hide Advanced Panel"),


### PR DESCRIPTION
## Description ##
Input_Config.xml had an incorrect ActionId of Toggle5movement. This was changed to Toggle5Movement.

Localisation.sql had a syntax error with ; when a , should have been used.

## How was this tested? ##
Tested running within my own game. Database.log no longer output errors related to these files.